### PR TITLE
Added the missig HostKeyCallBack parameter in the SSH config

### DIFF
--- a/sshclient.go
+++ b/sshclient.go
@@ -56,6 +56,7 @@ func DialWithKey(addr, user, keyfile string) (*Client, error) {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
+		HostKeyCallback: ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error { return nil }),
 	}
 
 	return Dial("tcp", addr, config)


### PR DESCRIPTION
It seems that the `HostKeyCallback` is required when connecting with a key.