### PR TITLE
Errors while "go build" fixed 

### DIFF
--- a/sshclient.go
+++ b/sshclient.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"net"
 )
 
 type remoteScriptType byte


### PR DESCRIPTION
Errors while "go build" 

.\sshclient.go:59:39: cannot convert func literal (type func(string, <T>, ssh.PublicKey) error) to type ssh.HostKeyCallback
 .\sshclient.go:59:69: undefined: net

Bugfix
Make Build not to complain anymore.

imported "net"