### PR TITLE
added HostKeyCallback to DialWithPasswd

### DIFF
--- a/sshclient.go
+++ b/sshclient.go
@@ -5,11 +5,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ssh"
 	"io"
 	"io/ioutil"
-	"os"
 	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh"
 )
 
 type remoteScriptType byte
@@ -35,6 +36,7 @@ func DialWithPasswd(addr, user, passwd string) (*Client, error) {
 		Auth: []ssh.AuthMethod{
 			ssh.Password(passwd),
 		},
+		HostKeyCallback: ssh.HostKeyCallback(func(hostname string, remote net.Addr, key ssh.PublicKey) error { return nil }),
 	}
 
 	return Dial("tcp", addr, config)


### PR DESCRIPTION
Did the same for DialWithPasswd like in https://github.com/helloyi/go-sshclient/pull/1. This fixes "must specify HostKeyCallback" issue.