### PR TITLE
added DialWithConnection function

### DIFF
--- a/sshclient.go
+++ b/sshclient.go
@@ -101,6 +101,20 @@ func Dial(network, addr string, config *ssh.ClientConfig) (*Client, error) {
 	}, nil
 }
 
+// DialWithConnection starts a client connection using existing net.Conn.
+func DialWithConnection(conn net.Conn, addr string, config *ssh.ClientConfig) (*Client, error) {
+	ncc, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
+	if err != nil {
+		return nil, err
+	}
+
+	client := ssh.NewClient(ncc, chans, reqs)
+
+	return &Client{
+		client: client,
+	}, nil
+}
+
 // Close closes the underlying client network connection.
 func (c *Client) Close() error {
 	return c.client.Close()


### PR DESCRIPTION
In case of connecting through a bastion host, it is necessary to allow dial using existing net.Conn.

Look: https://stackoverflow.com/questions/35906991/go-x-crypto-ssh-how-to-establish-ssh-connection-to-private-instance-over-a-ba